### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "2.6"
 install:
   - pip install -r requirements.txt
   - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 from setuptools import setup
+import sys
+
 import speakeasy
+
+if sys.version_info < (2, 7):
+    sys.exit('Sorry, Python < 2.7 is not supported')
 
 setup(
     name='speakeasy',
@@ -7,7 +12,6 @@ setup(
     description='Metrics aggregation server',
     author='Eric Wong',
     install_requires=[
-        'argparse',
         'pyzmq',
         'ujson',
     ],

--- a/speakeasy/__init__.py
+++ b/speakeasy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
 
 __title__ = 'speakeasy'
-__version__ = '1.3'
+__version__ = '1.3.1'
 __author__ = 'Eric Wong'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27
+envlist = py27
 
 [testenv]
 deps=


### PR DESCRIPTION
The argparse library requirement breaks builds on 2.7 installs.