### PR TITLE
Now supports both Python 2 (2.7) and Python 3(3.5+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ MANIFEST
 .coverage
 .tox
 .vscode
+.nose*
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: python
+dist: xenial  # https://docs.travis-ci.com/user/languages/python/#python-37-and-higher
+
 python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
   - "2.7"
+
 install:
   - pip install -r requirements.txt
   - pip install coveralls
+
 script:
-  nosetests --with-coverage --cover-package=speakeasy
+  - flake8 speakeasy test
+  - nosetests --with-coverage --cover-package=speakeasy
+
 after_success:
   coveralls

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+from __future__ import absolute_import
 import sys
 import os
 import sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argparse
 nose
-pyzmq
+pyzmq>=16,<18
 ujson
 unittest2
 mock
+flake8

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from setuptools import setup
 import sys
 
@@ -25,7 +26,9 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: Apache Software License',
     ],
 )

--- a/speakeasy/__init__.py
+++ b/speakeasy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
 
 __title__ = 'speakeasy'
-__version__ = '1.3.1'
+__version__ = '2.0.0'
 __author__ = 'Eric Wong'

--- a/speakeasy/emitter/simple.py
+++ b/speakeasy/emitter/simple.py
@@ -9,6 +9,7 @@ this emitter will attempt to write to `metrics.out` barring any permissions issu
 
 The special names `stdout` or `stderr` will send outputs to the appropriate stream
 """
+from __future__ import absolute_import
 import logging
 import sys
 

--- a/speakeasy/utils.py
+++ b/speakeasy/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import math
 
 

--- a/test/test_speakeasy.py
+++ b/test/test_speakeasy.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest2 as unittest
 import os
 import stat
@@ -7,50 +8,52 @@ from test_util import get_random_free_port
 from speakeasy.speakeasy import Speakeasy
 import speakeasy.speakeasy as speakeasy
 import logging
+import logging.handlers
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s [%(levelname)s] %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+# custom logger to bypass nose logging capture
 logger = logging.getLogger()
+handler = logging.handlers.RotatingFileHandler("test_speakeasy.log")
+handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] (%(funcName)s) %(message)s',
+                                       datefmt='%Y-%m-%d %H:%M:%S'))
+logger.addHandler(handler)
 
 G_SPEAKEASY_HOST = '0.0.0.0'
 G_PUB_PORT = str(get_random_free_port())
 G_CMD_PORT = str(get_random_free_port())
-G_METRIC_SOCKET = '/var/tmp/test_metric_{0}'.format(random.random())
+G_METRIC_SOCKET = '/var/tmp/test_metric_socket_{0}'.format(random.random())
+G_EMITTER_LOG = '/var/tmp/test_metrics_{0}.out'.format(random.random())
 speakeasy.QUEUE_WAIT_SECS = 1
 
 
 def gen_speakeasy_server():
     return Speakeasy(G_SPEAKEASY_HOST, G_METRIC_SOCKET, G_CMD_PORT, G_PUB_PORT,
-                     'simple', ['filename=/var/tmp/test_metrics.out'], 60)
+                     'simple', ['filename=' + G_EMITTER_LOG], 60)
 
 
 class TestSpeakeasy(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        logger.info("**TESTS**: Setup starts")
         self.srv = gen_speakeasy_server()
-        logger.info("**TESTS**: Server generated")
+        logger.info("Server generated: %s", self.srv)
         self.sub_socket = zmq.Context().socket(zmq.SUB)
         self.sub_socket.connect('tcp://localhost:{0}'.format(G_PUB_PORT))
-        self.sub_socket.setsockopt(zmq.SUBSCRIBE, '')
+        self.sub_socket.setsockopt_string(zmq.SUBSCRIBE, u'')
+        self.sub_socket.setsockopt(zmq.LINGER, 0)
 
         self.poller = zmq.Poller()
         self.poller.register(self.sub_socket, zmq.POLLIN)
 
         self.srv.start()
-        logger.info("**TESTS**: Setup ends")
 
     @classmethod
     def tearDownClass(self):
-        logger.info("**TESTS**: Class teardown begins")
-        logger.info("**TESTS**: Beginning server shutdown")
+        logger.info("tearing down test class")
         self.srv.shutdown()
-        logger.info("**TESTS**: Server shutdown complete")
-        logger.info("**TESTS**: Closing socket")
         self.sub_socket.close()
-        logger.info("**TESTS**: Socket closed.")
-        logger.info("**TESTS**: Class teardown complete")
+        if os.path.exists(G_METRIC_SOCKET):
+            os.remove(G_METRIC_SOCKET)
+        if os.path.exists(G_EMITTER_LOG):
+            os.remove(G_EMITTER_LOG)
 
     def setUp(self):
         pass
@@ -73,8 +76,7 @@ class TestSpeakeasy(unittest.TestCase):
         self.assertEqual(self.srv.cmd_port, G_CMD_PORT)
         self.assertEqual(self.srv.pub_port, G_PUB_PORT)
         self.assertEqual(self.srv.emission_interval, 60)
-        self.assertEqual(self.srv.emitter_args['filename'],
-                         '/var/tmp/test_metrics.out')
+        self.assertEqual(self.srv.emitter_args['filename'], G_EMITTER_LOG)
         self.assertEqual(len(self.srv.metrics), 0)
         self.assertFalse(self.srv.is_shutdown())
 
@@ -86,52 +88,46 @@ class TestSpeakeasy(unittest.TestCase):
     def test_process_command(self):
         req_sock = zmq.Context().socket(zmq.REQ)
         req_sock.connect('tcp://localhost:{0}'.format(G_CMD_PORT))
-        req_sock.send('{}')
+        req_sock.send_string('{}')
+        req_sock.close()
         # TODO: fill this when process_command is implemented
 
     def test_socket_cleanup(self):
-        tmp_metric_socket = '/var/tmp/tmp_test_metric_socket{0}'.format(
-            random.random())
-        srv = Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket,
-                        str(get_random_free_port()),
-                        str(get_random_free_port()), 'simple',
-                        ['filename=/var/tmp/test_metrics.out'],
-                        60, socket_mod=0666)
+        tmp_metric_socket = '/var/tmp/test_metric_socket_cleanup{0}'.format(random.random())
+        srv = Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket, str(get_random_free_port()), str(get_random_free_port()),
+                        'simple', ['filename=' + G_EMITTER_LOG], 60, socket_mod=0o666)
+        logger.info("Server generated: %s", srv)
         srv.start()
         self.assertTrue(os.path.exists(tmp_metric_socket))
         srv.shutdown()
         self.assertFalse(os.path.exists(tmp_metric_socket))
 
     def test_socket_mod(self):
-        tmp_metric_socket = '/var/tmp/tmp_test_metric_{0}'.format(
-            random.random())
-        Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket,
-                  str(get_random_free_port()),
-                  str(get_random_free_port()), 'simple',
-                  ['filename=/var/tmp/test_metrics.out'],
-                  60, socket_mod=0666)
-        self.assertEqual(oct(stat.S_IMODE(os.stat(tmp_metric_socket).st_mode)),
-                         '0666')
+        tmp_metric_socket = '/var/tmp/test_metric_mod{0}'.format(random.random())
 
-        Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket,
-                  str(get_random_free_port()),
-                  str(get_random_free_port()), 'simple',
-                  ['filename=/var/tmp/test_metrics.out'], 60)
-        self.assertNotEqual(
-            oct(stat.S_IMODE(os.stat(tmp_metric_socket).st_mode)), '0666')
+        srv = Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket, str(get_random_free_port()), str(get_random_free_port()),
+                        'simple', ['filename=' + G_EMITTER_LOG], 60, socket_mod=0o666)
+        logger.info("Server generated: %s", srv)
+        self.assertEqual((stat.S_IMODE(os.stat(tmp_metric_socket).st_mode)), 0o666)
+        srv.shutdown()
+
+        srv = Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket, str(get_random_free_port()), str(get_random_free_port()),
+                        'simple', ['filename=' + G_EMITTER_LOG], 60)
+        logger.info("Server generated: %s", srv)
+        self.assertNotEqual((stat.S_IMODE(os.stat(tmp_metric_socket).st_mode)), 0o666)
+        srv.shutdown()
 
     def test_start_without_pub_port(self):
-        tmp_metric_socket = '/var/tmp/tmp_test_metric_{0}'.format(
-            random.random())
-        s = Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket,
-                      str(get_random_free_port()), None, 'simple',
-                      ['filename=/var/tmp/test_metrics.out'], 60)
+        tmp_metric_socket = '/var/tmp/test_metric_wo_pub_port{0}'.format(random.random())
+        s = Speakeasy(G_SPEAKEASY_HOST, tmp_metric_socket, str(get_random_free_port()), None,
+                      'simple', ['filename=' + G_EMITTER_LOG], 60)
+        logger.info("Server generated: %s", s)
         self.assertEqual(s.metric_socket, tmp_metric_socket)
         self.assertEqual(s.pub_port, None)
         self.assertEqual(s.emission_interval, 60)
-        self.assertEqual(s.emitter_args['filename'],
-                         '/var/tmp/test_metrics.out')
+        self.assertEqual(s.emitter_args['filename'], G_EMITTER_LOG)
         self.assertEqual(len(s.metrics), 0)
+        s.shutdown()
 
 
 if __name__ == '__main__':

--- a/test/test_speakeasy_legacy.py
+++ b/test/test_speakeasy_legacy.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import unittest2 as unittest
 import random
 import socket
@@ -9,34 +10,40 @@ from test_util import get_random_free_port
 from speakeasy.speakeasy import Speakeasy
 import speakeasy.speakeasy as speakeasy
 import logging
+import logging.handlers
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s [%(levelname)s] %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+# custom logger to bypass nose logging capture
 logger = logging.getLogger()
+handler = logging.handlers.RotatingFileHandler("test_speakeasy_legacy.log")
+handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] (%(funcName)s) %(message)s',
+                                       datefmt='%Y-%m-%d %H:%M:%S'))
+logger.addHandler(handler)
 
 G_SPEAKEASY_HOST = '0.0.0.0'
 G_PUB_PORT = str(get_random_free_port())
 G_CMD_PORT = str(get_random_free_port())
-G_METRIC_SOCKET = '/var/tmp/test_metric_{0}'.format(random.random())
-G_LEGACY_METRIC_SOCKET = '/var/tmp/legacy_metric_{0}'.format(random.random())
+G_METRIC_SOCKET = '/var/tmp/test_metric_socket_{0}'.format(random.random())
+G_LEGACY_METRIC_SOCKET = '/var/tmp/test_legacy_metric_socket_{0}'.format(random.random())
+G_EMITTER_LOG = '/var/tmp/test_metrics_{0}.out'.format(random.random())
 speakeasy.QUEUE_WAIT_SECS = 1
 
 
 def gen_speakeasy_server():
     return Speakeasy(G_SPEAKEASY_HOST, G_METRIC_SOCKET, G_CMD_PORT, G_PUB_PORT,
-                     'simple', ['filename=/var/tmp/test_metrics.out'],
+                     'simple', ['filename=' + G_EMITTER_LOG],
                      60, G_LEGACY_METRIC_SOCKET)
 
 
 class TestSpeakeasy(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        logger.info("Creating speakeasy")
         self.srv = gen_speakeasy_server()
-
+        logger.info("Speakeasy: %s", self.srv)
         self.sub_socket = zmq.Context().socket(zmq.SUB)
         self.sub_socket.connect('tcp://localhost:{0}'.format(G_PUB_PORT))
-        self.sub_socket.setsockopt(zmq.SUBSCRIBE, '')
+        self.sub_socket.setsockopt_string(zmq.SUBSCRIBE, u'')
+        self.sub_socket.setsockopt(zmq.LINGER, 0)
 
         self.poller = zmq.Poller()
         self.poller.register(self.sub_socket, zmq.POLLIN)
@@ -45,7 +52,15 @@ class TestSpeakeasy(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
+        logger.info("tearing down test class")
         self.srv.shutdown()
+        self.sub_socket.close()
+        if os.path.exists(G_METRIC_SOCKET):
+            os.remove(G_METRIC_SOCKET)
+        if os.path.exists(G_LEGACY_METRIC_SOCKET):
+            os.remove(G_LEGACY_METRIC_SOCKET)
+        if os.path.exists(G_EMITTER_LOG):
+            os.remove(G_EMITTER_LOG)
 
     def setUp(self):
         pass
@@ -61,8 +76,7 @@ class TestSpeakeasy(unittest.TestCase):
         self.assertEqual(self.srv.pub_port, G_PUB_PORT)
         self.assertEqual(self.srv.emission_interval, 60)
         self.assertEqual(self.srv.legacy, G_LEGACY_METRIC_SOCKET)
-        self.assertEqual(self.srv.emitter_args['filename'],
-                         '/var/tmp/test_metrics.out')
+        self.assertEqual(self.srv.emitter_args['filename'], G_EMITTER_LOG)
         self.assertEqual(len(self.srv.metrics), 0)
         self.assertFalse(self.srv.is_shutdown())
 
@@ -78,36 +92,44 @@ class TestSpeakeasy(unittest.TestCase):
         self.clear_sub_socket()
         legacy_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
         legacy_sock.connect(G_LEGACY_METRIC_SOCKET)
-        legacy_sock.send('test_cnt3|10|COUNTER')
+        legacy_sock.send('test_cnt3|10|COUNTER'.encode())
         self.assertGreater(len(dict(self.poller.poll(500))), 0)
+        metrics = None
         while True:  # skip internal metrics
-            metrics = json.loads(self.sub_socket.recv())
+            metrics = json.loads(self.sub_socket.recv_string())
             if metrics[0][1] != 'speakeasy':
                 break
+        self.assertNotEqual(metrics, None)
         self.assertEqual(len(metrics), 1)
         self.assertEqual(metrics[0][0], G_SPEAKEASY_HOST)
         self.assertEqual(metrics[0][1], u'__LEGACY__')
         self.assertEqual(metrics[0][2], u'test_cnt3')
         self.assertEqual(metrics[0][3], 'COUNTER')
         self.assertEqual(metrics[0][4], 10)
+        legacy_sock.close()
 
     def test_recreate_legacy_socket(self):
-        dummy_legacy_socket = '/tmp/__speakeasy_legacy_socket'
+        dummy_legacy_socket = '/var/tmp/test_speakeasy_legacy_socket_{0}'.format(random.random())
+        logger.info("Using dummy legacy socket as %s", dummy_legacy_socket)
         with open(dummy_legacy_socket, 'w') as sf:
             sf.write('\n')
+        srv = None
         with mock.patch('os.remove'):
             try:
-                Speakeasy(G_SPEAKEASY_HOST, G_METRIC_SOCKET,
-                          str(get_random_free_port()),
-                          str(get_random_free_port()), 'simple',
-                          ['filename=/var/tmp/test_metrics.out'],
-                          60, dummy_legacy_socket)
+                srv = Speakeasy(G_SPEAKEASY_HOST, G_METRIC_SOCKET,
+                                str(get_random_free_port()),
+                                str(get_random_free_port()), 'simple',
+                                ['filename=' + G_EMITTER_LOG],
+                                60, dummy_legacy_socket)
+                logger.info("Server generated: %s", srv)
             except socket.error:
                 # remove got patched, so we should get a address already init
                 # use socket error
                 pass
             os.remove.assert_called_once_with(dummy_legacy_socket)
-        os.remove(dummy_legacy_socket)
+        os.remove(dummy_legacy_socket)  # actually do it
+        if srv:
+            srv.shutdown()
 
 
 if __name__ == '__main__':

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import
 import zmq
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_random_free_port():
@@ -19,8 +22,22 @@ def filtered_metric_recv(sub_socket):
     "Receive a single non-speakeasy metric"
     while True:  # skip internal metrics
         try:
-            metrics = json.loads(sub_socket.recv(zmq.NOBLOCK))
+            metrics = json.loads(sub_socket.recv_string(zmq.NOBLOCK))
             if metrics[0][1] != 'speakeasy':
                 return metrics
+        except zmq.Again:
+            pass
         except zmq.ZMQError as e:
             logging.error("**TESTS**: Got error receiving zmq event: %s", e)
+
+
+def filtered_metrics_from_emitter(call_args_list):
+    "From the mocked calls to the emitters extract all the non-internal (app speakeasy) metrics"
+    filtered_metrics = []
+    for call in call_args_list:
+        args, kwargs = call
+        for metric in args[0]:
+            if metric[0] != "speakeasy":
+                filtered_metrics.append(metric)
+    logger.info("**TESTS**: Filtered emitter metrics=%s", filtered_metrics)
+    return filtered_metrics


### PR DESCRIPTION
- Use version agnostic *_string method to solve the bytes/string issues between py2/3
- Fix all unclean server shutdowns which were keeping sockets open between tests causing random hangups
- Make sure none of the tests leave behind any random temporary test files after they finish
- Make code flake8 compliant. Added flake8 to travis build steps
- Many many other random fixes
- Travis needs a specific linux image for python 3.7